### PR TITLE
Fixes Strict Standards for JPEG Quality

### DIFF
--- a/src/Pel.php
+++ b/src/Pel.php
@@ -141,7 +141,7 @@ class Pel {
      * @param int $quality an integer between 0 and 100 with 75 being
      * average quality and 95 very good quality.
      */
-    function setJPEGQuality($quality) {
+    static function setJPEGQuality($quality) {
         self::$quality = $quality;
     }
 
@@ -151,7 +151,7 @@ class Pel {
      *
      * @return int the quality.
      */
-    function getJPEGQuality() {
+    static function getJPEGQuality() {
         return self::$quality;
     }
 


### PR DESCRIPTION
Fixes:
Strict Standards: Non-static method Pel::getJPEGQuality() should not be called statically, assuming $this from incompatible context in PelDataWindow.php on line 135