### PR TITLE
Fixing issue with copyright tag

### DIFF
--- a/src/PelEntryAscii.php
+++ b/src/PelEntryAscii.php
@@ -319,6 +319,7 @@ class PelEntryTime extends PelEntryAscii {
                 /* Clean the timestamp: some timestamps are broken other
                  * separators than ':' and ' '. */
                 $d = preg_split('/[^0-9]+/', $timestamp);
+                for ($i=0; $i<3; $i++) if (empty($d[$i])) $d[$i] = 0;
                 $this->day_count = $this->convertGregorianToJd($d[0], $d[1], $d[2]);
                 $this->seconds   = $d[3]*3600 + $d[4]*60 + $d[5];
                 break;
@@ -410,7 +411,7 @@ class PelEntryTime extends PelEntryAscii {
      * Converts a Julian Day count to a UNIX timestamp.
      *
      * @param int $jd the Julian Day count.
-
+     *
      * @return mixed $timestamp the integer timestamp or false if the
      * day count cannot be represented as a UNIX timestamp.
      */
@@ -558,4 +559,3 @@ class PelEntryCopyright extends PelEntryAscii {
         return '';
     }
 }
-

--- a/src/PelEntryAscii.php
+++ b/src/PelEntryAscii.php
@@ -319,7 +319,7 @@ class PelEntryTime extends PelEntryAscii {
                 /* Clean the timestamp: some timestamps are broken other
                  * separators than ':' and ' '. */
                 $d = preg_split('/[^0-9]+/', $timestamp);
-                for ($i=0; $i<3; $i++) if (empty($d[$i])) $d[$i] = 0;
+                for ($i=0; $i<6; $i++) if (empty($d[$i])) $d[$i] = 0;
                 $this->day_count = $this->convertGregorianToJd($d[0], $d[1], $d[2]);
                 $this->seconds   = $d[3]*3600 + $d[4]*60 + $d[5];
                 break;

--- a/src/PelEntryNumber.php
+++ b/src/PelEntryNumber.php
@@ -134,7 +134,7 @@ abstract class PelEntryNumber extends PelEntry {
      *
      * @see getValue
      */
-    function setValue(/* $value... */) {
+    function setValue($x) {
         $value = func_get_args();
         $this->setValueArray($value);
     }

--- a/src/PelIfd.php
+++ b/src/PelIfd.php
@@ -372,6 +372,7 @@ class PelIfd implements IteratorAggregate, ArrayAccess {
                         PelFormat::ASCII);
 
                         $v = explode("\0", trim($data->getBytes(), ' '));
+                        if (!isset($v[1])) $v[1] = '';
                         return new PelEntryCopyright($v[0], $v[1]);
 
                     case PelTag::EXIF_VERSION:


### PR DESCRIPTION
Source: http://www.exiv2.org/tags.html

The copyright tag may contain ONE or TWO items. It is not guaranteed to be two items in the spec. When there is only one item, there is only a single NULL character, not a NULL separator with double-NULL termination. In this condition, $v[1] would not be set, and there for throw an error when trying to read this element within the array. 

Simple fix, check to see if the value is set, if not, set it to an empty string value.