### PR TITLE
Fixes PHP error for images with invalid copyright

### DIFF
--- a/src/PelIfd.php
+++ b/src/PelIfd.php
@@ -372,6 +372,10 @@ class PelIfd implements IteratorAggregate, ArrayAccess {
                         PelFormat::ASCII);
 
                         $v = explode("\0", trim($data->getBytes(), ' '));
+                        if (!isset($v[1])) {
+                            throw new PelException('Invalid copyright: %s',
+                            $data->getBytes());
+                        }
                         return new PelEntryCopyright($v[0], $v[1]);
 
                     case PelTag::EXIF_VERSION:


### PR DESCRIPTION
This fixes a "Undefined offset: 1" PHP error that would occur when PEL handled images with invalid/empty copyright metadata.

In my case, I had an image where `$v` resulted in:

    ['']