### PR TITLE
PelEntryVersion::setValue raises PHP warning in PHP 7.1

### DIFF
--- a/src/PelEntryVersion.php
+++ b/src/PelEntryVersion.php
@@ -104,6 +104,7 @@ class PelEntryVersion extends PelEntryUndefined
      */
     public function setValue($version = 0.0)
     {
+        $version = !empty($version) && is_numeric($version) ? $version : 0.0;
         $this->version = $version;
         $major = floor($version);
         $minor = ($version - $major) * 100;


### PR DESCRIPTION
when the $version parameter passed is non numeric:

_A non-numeric value encountered_