### PR TITLE
PelJpeg::saveFile should return a value

### DIFF
--- a/src/PelJpeg.php
+++ b/src/PelJpeg.php
@@ -591,10 +591,13 @@ class PelJpeg
      * @param
      *            string the filename to save in. An existing file with the
      *            same name will be overwritten!
+     *
+     * @return integer|FALSE The number of bytes that were written to the
+     *         file, or FALSE on failure.
      */
     public function saveFile($filename)
     {
-        file_put_contents($filename, $this->getBytes());
+        return file_put_contents($filename, $this->getBytes());
     }
 
     /**


### PR DESCRIPTION
I suggest to pass over the value returned by _file_put_contents_, so that calling code can manage failures.