### PR TITLE
Added reverse lookup methods, fixed PHPDOC for PelTag enumerations

### DIFF
--- a/src/PelEntry.php
+++ b/src/PelEntry.php
@@ -92,7 +92,7 @@ abstract class PelEntry
     /**
      * The {@link PelTag} of this entry.
      *
-     * @var PelTag
+     * @var int
      */
     protected $tag;
 
@@ -113,7 +113,7 @@ abstract class PelEntry
     /**
      * Return the tag of this entry.
      *
-     * @return PelTag the tag of this entry.
+     * @return int the tag of this entry.
      */
     public function getTag()
     {

--- a/src/PelEntryByte.php
+++ b/src/PelEntryByte.php
@@ -56,7 +56,7 @@ class PelEntryByte extends PelEntryNumber
      * getValue} method will always return an array except for when a
      * single integer argument is given here.
      *
-     * @param PelTag $tag
+     * @param int $tag
      *            the tag which this entry represents. This
      *            should be one of the constants defined in {@link PelTag}
      *            which has format {@link PelFormat::BYTE}.

--- a/src/PelEntryException.php
+++ b/src/PelEntryException.php
@@ -59,7 +59,7 @@ class PelEntryException extends PelException
     /**
      * The tag of the entry (if known).
      *
-     * @var PelTag
+     * @var int
      */
     protected $tag;
 
@@ -78,7 +78,7 @@ class PelEntryException extends PelException
     /**
      * Get the tag associated with the exception.
      *
-     * @return PelTag the tag. If no tag is set, null is returned.
+     * @return int the tag. If no tag is set, null is returned.
      */
     public function getTag()
     {

--- a/src/PelEntryLong.php
+++ b/src/PelEntryLong.php
@@ -74,7 +74,7 @@ class PelEntryLong extends PelEntryNumber
      * extracted.
      *
      * @param
-     *            PelTag the tag which this entry represents. This
+     *            int the tag which this entry represents. This
      *            should be one of the constants defined in {@link PelTag},
      *            e.g., {@link PelTag::IMAGE_WIDTH}, or any other tag which can
      *            have format {@link PelFormat::LONG}.

--- a/src/PelEntryRational.php
+++ b/src/PelEntryRational.php
@@ -65,7 +65,7 @@ class PelEntryRational extends PelEntryLong
      * Make a new entry that can hold an unsigned rational.
      *
      * @param
-     *            PelTag the tag which this entry represents. This should
+     *            int the tag which this entry represents. This should
      *            be one of the constants defined in {@link PelTag}, e.g., {@link
      *            PelTag::X_RESOLUTION}, or any other tag which can have format
      *            {@link PelFormat::RATIONAL}.

--- a/src/PelEntrySByte.php
+++ b/src/PelEntrySByte.php
@@ -56,7 +56,7 @@ class PelEntrySByte extends PelEntryNumber
      * method will always return an array except for when a single
      * integer argument is given here.
      *
-     * @param PelTag $tag
+     * @param int $tag
      *            the tag which this entry represents. This
      *            should be one of the constants defined in {@link PelTag}
      *            which has format {@link PelFormat::BYTE}.

--- a/src/PelEntrySLong.php
+++ b/src/PelEntrySLong.php
@@ -56,7 +56,7 @@ class PelEntrySLong extends PelEntryNumber
      * single integer is given.
      *
      * @param
-     *            PelTag the tag which this entry represents. This
+     *            int the tag which this entry represents. This
      *            should be one of the constants defined in {@link PelTag}
      *            which have format {@link PelFormat::SLONG}.
      *

--- a/src/PelEntrySRational.php
+++ b/src/PelEntrySRational.php
@@ -55,7 +55,7 @@ class PelEntrySRational extends PelEntrySLong
      * Make a new entry that can hold a signed rational.
      *
      * @param
-     *            PelTag the tag which this entry represents. This should
+     *            int the tag which this entry represents. This should
      *            be one of the constants defined in {@link PelTag}, e.g., {@link
      *            PelTag::SHUTTER_SPEED_VALUE}, or any other tag which can have
      *            format {@link PelFormat::SRATIONAL}.

--- a/src/PelEntrySShort.php
+++ b/src/PelEntrySShort.php
@@ -53,7 +53,7 @@ class PelEntrySShort extends PelEntryNumber
      * getValue} method will always return an array except for when a
      * single integer argument is given here.
      *
-     * @param PelTag $tag
+     * @param int $tag
      *            the tag which this entry represents. This
      *            should be one of the constants defined in {@link PelTag}
      *            which has format {@link PelFormat::SSHORT}.

--- a/src/PelEntryShort.php
+++ b/src/PelEntryShort.php
@@ -73,7 +73,7 @@ class PelEntryShort extends PelEntryNumber
      * instead of an array with one integer element, which would then
      * have to be extracted.
      *
-     * @param PelTag $tag
+     * @param int $tag
      *            the tag which this entry represents. This should be
      *            one of the constants defined in {@link PelTag}, e.g., {@link
      *            PelTag::IMAGE_WIDTH}, {@link PelTag::ISO_SPEED_RATINGS},

--- a/src/PelIfd.php
+++ b/src/PelIfd.php
@@ -572,7 +572,7 @@ class PelIfd implements \IteratorAggregate, \ArrayAccess
      * treated as private tags and will be allowed everywhere (use this
      * for testing or for implementing your own types of tags).
      *
-     * @param PelTag $tag
+     * @param int $tag
      *            the tag.
      *
      * @return boolean true if the tag is considered valid in this IFD,
@@ -829,7 +829,7 @@ class PelIfd implements \IteratorAggregate, \ArrayAccess
      * // ... do something with the F-number.
      * </code>
      *
-     * @param PelTag $tag
+     * @param int $tag
      *            the offset to check.
      *
      * @return boolean whether the tag exists.
@@ -850,7 +850,7 @@ class PelIfd implements \IteratorAggregate, \ArrayAccess
      * $entry = $ifd[PelTag::FNUMBER];
      * </code>
      *
-     * @param PelTag $tag
+     * @param int $tag
      *            the tag to return. It is an error to ask for a tag
      *            which is not in the IFD, just like asking for a non-existant
      *            array entry.
@@ -876,8 +876,8 @@ class PelIfd implements \IteratorAggregate, \ArrayAccess
      * Note that the actual array index passed is ignored! Instead the
      * {@link PelTag} from the entry is used.
      *
-     * @param PelTag $tag
-     *            the offset to update.
+     * @param int $tag
+     *            unused.
      *
      * @param PelEntry $e
      *            the new value.
@@ -903,7 +903,7 @@ class PelIfd implements \IteratorAggregate, \ArrayAccess
      * unset($ifd[PelTag::EXPOSURE_BIAS_VALUE])
      * </code>
      *
-     * @param PelTag $tag
+     * @param int $tag
      *            the offset to delete.
      */
     public function offsetUnset($tag)
@@ -914,7 +914,7 @@ class PelIfd implements \IteratorAggregate, \ArrayAccess
     /**
      * Retrieve an entry.
      *
-     * @param PelTag $tag
+     * @param int $tag
      *            the tag identifying the entry.
      *
      * @return PelEntry the entry associated with the tag, or null if no

--- a/src/PelTag.php
+++ b/src/PelTag.php
@@ -1629,6 +1629,8 @@ class PelTag
     /**
      * Reverse lookup of a tag id by its short name. Return false for the unknown tag name.
      *
+     * @deprecated Use getExifTagByName() and getGpsTagByName() to distinct the type of tag.
+     *
      * @param string $name
      *            tag short name.
      *

--- a/src/PelTag.php
+++ b/src/PelTag.php
@@ -1645,33 +1645,33 @@ class PelTag
         return array_search($name, static::$gpsTagsShort);
     }
 
-	/**
-	 * Reverse lookup of a EXIF related tag id by its short name. Return false for the unknown tag name.
-	 *
-	 * @param string $name
-	 *            tag short name.
-	 *
-	 * @return mixed (bool|int)
-	 *            the tag.
-	 */
-	public static function getExifTagByName($name)
-	{
-		return array_search($name, static::$exifTagsShort);
-	}
+    /**
+     * Reverse lookup of a EXIF related tag id by its short name. Return false for the unknown tag name.
+     *
+     * @param string $name
+     *            tag short name.
+     *
+     * @return mixed (bool|int)
+     *            the tag.
+     */
+    public static function getExifTagByName($name)
+    {
+        return array_search($name, static::$exifTagsShort);
+    }
 
-	/**
-	 * Reverse lookup of a GPS related tag id by its short name. Return false for the unknown tag name.
-	 *
-	 * @param string $name
-	 *            tag short name.
-	 *
-	 * @return mixed (bool|int)
-	 *            the tag.
-	 */
-	public static function getGpsTagByName($name)
-	{
-		return array_search($name, static::$gpsTagsShort);
-	}
+    /**
+     * Reverse lookup of a GPS related tag id by its short name. Return false for the unknown tag name.
+     *
+     * @param string $name
+     *            tag short name.
+     *
+     * @return mixed (bool|int)
+     *            the tag.
+     */
+    public static function getGpsTagByName($name)
+    {
+        return array_search($name, static::$gpsTagsShort);
+    }
 
     /**
      * Returns string defining unknown tag.

--- a/src/PelTag.php
+++ b/src/PelTag.php
@@ -1612,7 +1612,7 @@ class PelTag
      * @param array $container
      *            {@link PelTag::EXIF_TAGS_SHORT}, {@link PelTag::EXIF_TAGS_TITLE},
      *            {@link PelTag::GPS_TAGS_SHORT} or {@link PelTag::GPS_TAGS_TITLE} container.
-     * @param PelTag $tag
+     * @param int $tag
      *            the tag.
      *
      * @return string short name or long name of the tag.
@@ -1645,6 +1645,34 @@ class PelTag
         return array_search($name, static::$gpsTagsShort);
     }
 
+	/**
+	 * Reverse lookup of a EXIF related tag id by its short name. Return false for the unknown tag name.
+	 *
+	 * @param string $name
+	 *            tag short name.
+	 *
+	 * @return mixed (bool|int)
+	 *            the tag.
+	 */
+	public static function getExifTagByName($name)
+	{
+		return array_search($name, static::$exifTagsShort);
+	}
+
+	/**
+	 * Reverse lookup of a GPS related tag id by its short name. Return false for the unknown tag name.
+	 *
+	 * @param string $name
+	 *            tag short name.
+	 *
+	 * @return mixed (bool|int)
+	 *            the tag.
+	 */
+	public static function getGpsTagByName($name)
+	{
+		return array_search($name, static::$gpsTagsShort);
+	}
+
     /**
      * Returns string defining unknown tag.
      *
@@ -1667,7 +1695,7 @@ class PelTag
      *            {@link PelIfd::IFD1}, {@link PelIfd::EXIF}, {@link PelIfd::GPS},
      *            or {@link PelIfd::INTEROPERABILITY}.
      *
-     * @param PelTag $tag
+     * @param int $tag
      *            the tag.
      *
      * @return string the short name of the tag, e.g., 'ImageWidth' for
@@ -1698,7 +1726,7 @@ class PelTag
      *            {@link PelIfd::IFD1}, {@link PelIfd::EXIF}, {@link PelIfd::GPS},
      *            or {@link PelIfd::INTEROPERABILITY}.
      *
-     * @param PelTag $tag
+     * @param int $tag
      *            the tag.
      *
      * @return string the title of the tag, e.g., 'Image Width' for the

--- a/src/PelWrongComponentCountException.php
+++ b/src/PelWrongComponentCountException.php
@@ -63,7 +63,7 @@ class PelWrongComponentCountException extends \lsolesen\pel\PelEntryException
      * @param int $type
      *            the type of IFD.
      *
-     * @param PelTag $tag
+     * @param int $tag
      *            the tag for which the violation was found.
      *
      * @param int $found

--- a/test/PelTagTest.php
+++ b/test/PelTagTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * PEL: PHP Exif Library.
+ * A library with support for reading and
+ * writing all Exif headers in JPEG and TIFF images using PHP.
+ *
+ * Copyright (C) 2004, 2006 Martin Geisler.
+ * Copyright (C) 2017 Johannes Weberhofer
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program in the file COPYING; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ */
+use lsolesen\pel\PelIfd;
+use PHPUnit\Framework\TestCase;
+use lsolesen\pel\PelTag;
+
+
+class PelTagTest extends TestCase
+{
+    const NONEXISTENT_TAG_NAME = 'nonexistent tag name';
+    const NONEXISTENT_EXIF_TAG = 0xFCFC;
+    const NONEXISTENT_GPS_TAG = 0xFCFC;
+    const EXIF_TAG_NAME = 'ImageDescription';
+    const GPS_TAG_NAME = 'GPSLongitude';
+    const EXIF_TAG = PelTag::IMAGE_DESCRIPTION;
+    const GPS_TAG = PelTag::GPS_LONGITUDE;
+
+    function testReverseLookup()
+    {
+        $this->assertSame(false, PelTag::getExifTagByName(self::NONEXISTENT_TAG_NAME), 'Non-existent EXIF tag name');
+        $this->assertSame(false, PelTag::getGpsTagByName(self::NONEXISTENT_TAG_NAME), 'Non-existent GPS tag name');
+        $this->assertStringStartsWith('Unknown: ', PelTag::getName(PelIfd::IFD0, self::NONEXISTENT_EXIF_TAG),
+            'Non-existent EXIF tag');
+        $this->assertStringStartsWith('Unknown: ', PelTag::getName(PelIfd::GPS, self::NONEXISTENT_GPS_TAG),
+            'Non-existent GPS tag');
+
+        $this->assertSame(static::EXIF_TAG, PelTag::getExifTagByName(self::EXIF_TAG_NAME), 'EXIF tag name');
+        $this->assertSame(static::GPS_TAG, PelTag::getGpsTagByName(self::GPS_TAG_NAME), 'GPS tag name');
+        $this->assertEquals(static::EXIF_TAG_NAME, PelTag::getName(PelIfd::IFD0, self::EXIF_TAG), 'EXIF tag');
+        $this->assertEquals(static::GPS_TAG_NAME, PelTag::getName(PelIfd::GPS, self::GPS_TAG), 'GPS tag');
+    }
+}


### PR DESCRIPTION
Added new reverse lookup methods: getExifTagByName() and getGpsTagByName(). There is no way to tell what type of tag was returned by the getTagByName, making it unusable. I suggest deprecating getTagByName() as soon as possible, will delete it from branch if you confirm this.
Fixed inconsistent PHPDOC parameter types for PelTag enumerations, which were erroneously referring to PelTag type. Every method that use tag wants int as an argument, not a PelTag instance. Also, PelEntry and PelEntryException use int as their $tag property, not PelEntry instance.